### PR TITLE
Require custom data attribute on the form to identify payfields utilizing form

### DIFF
--- a/demos/payfields/index.html
+++ b/demos/payfields/index.html
@@ -25,7 +25,7 @@
 
         <div class='container'>
             <h2>Payfields in a Bootstrap styled form</h2>
-            <form action="/charge" data-beanstream-payfields-form method="POST" id="myForm">
+            <form action="/charge" method="POST" id="myForm">
                 <div class='form-group'>
                     <label>Card Number</label>
                     <div data-beanstream-target='ccNumber_input'></div>
@@ -46,7 +46,7 @@
                 Path set relative to host for demo. In production use absolute path:
                 https://payform.beanstream.com/payfields/beanstream_payfields.js
                 -->
-                <script src='payfields/beanstream_payfields.js' id="myScript"></script>
+                <script src='payfields/beanstream_payfields.js' id="payfields-script"></script>
 
                 <button type='submit' class='btn btn-default' id="myButton">Submit</button>
             </form>

--- a/demos/payfields/index.html
+++ b/demos/payfields/index.html
@@ -25,7 +25,7 @@
 
         <div class='container'>
             <h2>Payfields in a Bootstrap styled form</h2>
-            <form action="/charge" method="POST" id="myForm">
+            <form action="/charge" data-beanstream-payfields-form method="POST" id="myForm">
                 <div class='form-group'>
                     <label>Card Number</label>
                     <div data-beanstream-target='ccNumber_input'></div>

--- a/payfields/assets/js/app.js
+++ b/payfields/assets/js/app.js
@@ -22,10 +22,13 @@
         // Work around for browsers that do not support document.currentScript
         // source: http://www.2ality.com/2014/05/current-script.html
         // This will not work for if script is loaded async, so we cannot support async in IE8 or 9
-        var payfieldsForm = document.querySelector('[data-beanstream-payfields-form]');
         var currentScript = document.currentScript ||   (function() {
-            var scripts = payfieldsForm.getElementsByTagName('script');
-            return scripts[scripts.length - 1];
+            var scriptId = document.getElementById('payfields-script');
+            if (scriptId) {
+                return scriptId;
+            } else {
+                console.log('Error:The script tag with beanstream_payfields.js requires id value \'payfields-script\'');
+            };
         })();
 
         self.model = new beanstream.FormModel();

--- a/payfields/assets/js/app.js
+++ b/payfields/assets/js/app.js
@@ -22,8 +22,9 @@
         // Work around for browsers that do not support document.currentScript
         // source: http://www.2ality.com/2014/05/current-script.html
         // This will not work for if script is loaded async, so we cannot support async in IE8 or 9
-        var currentScript = document.currentScript || (function() {
-            var scripts = document.getElementsByTagName('script');
+        var payfieldsForm = document.querySelector('[data-beanstream-payfields-form]');
+        var currentScript = document.currentScript ||   (function() {
+            var scripts = payfieldsForm.getElementsByTagName('script');
             return scripts[scripts.length - 1];
         })();
 


### PR DESCRIPTION
This is a breaking change, thus the v2.0.0 branch was created. 
The build of v2.0.0 is intended to be built and hosted by a different endpoint than the previous versions of payfields.
In order to use this new version, integrators must add the custom HTML attribute 'data-beanstream-payfields-form' to the form that utilizes payfields.
The problem with the previous code is detailed in issue #77 

